### PR TITLE
linux: implement path normalization

### DIFF
--- a/Source/Core/Inc/UnGcc.h
+++ b/Source/Core/Inc/UnGcc.h
@@ -159,6 +159,14 @@ static_assert((char)-1 < 0, "char must be signed.");
 #define USEEK_END SEEK_END
 #define USEEK_SET SEEK_SET
 
+// Pathnames.
+#ifdef PLATFORM_WIN32
+#define PATH(s) s
+#else
+#define PATH(s) appUnixPath( s )
+char* appUnixPath( const char* Path );
+#endif
+
 // NULL.
 #ifndef NULL
 #define NULL 0
@@ -167,9 +175,11 @@ static_assert((char)-1 < 0, "char must be signed.");
 // Platform-specific strings.
 #ifdef PLATFORM_WIN32
 #define LINE_TERMINATOR "\r\n"
+#define PATH_SEPARATOR "\\"
 #define DLLEXT ".dll"
 #else
 #define LINE_TERMINATOR "\n"
+#define PATH_SEPARATOR "/"
 #define DLLEXT ".so"
 #endif
 

--- a/Source/Core/Inc/UnVcWin32.h
+++ b/Source/Core/Inc/UnVcWin32.h
@@ -139,11 +139,15 @@ typedef struct _iobuf FILE;
 #define USEEK_END 2
 #define USEEK_SET 0
 
+// Pathnames.
+#define PATH(s) s
+
 // NULL.
 #define NULL 0
 
 // Platform-specific strings.
 #define LINE_TERMINATOR "\r\n"
+#define PATH_SEPARATOR "\\"
 #define DLLEXT ".dll"
 
 // Package implementation.

--- a/Source/Core/Src/UnFile.cpp
+++ b/Source/Core/Src/UnFile.cpp
@@ -446,11 +446,6 @@ CORE_API TArray<FString> appFindFiles( const char* Spec )
 	// Initialize Path to Filename.
 	appStrcpy( Path, Spec );
 
-	// Convert MS "\" to Unix "/".
-	for( Cur = Path; *Cur != '\0'; Cur++ )
-		if( *Cur == '\\' )
-			*Cur = '/';
-
 	// Separate path and filename.
 	Filestart = Path;
 	for( Cur = Path; *Cur != '\0'; Cur++ )
@@ -560,13 +555,6 @@ CORE_API FILE* appFopen( const char* Path, const char* Mode )
 	// Case-insensitive search.
 	char DirNameBuf[1024], TmpName[1024];
 	appStrncpy( DirNameBuf, Path, sizeof(DirNameBuf) - 1 );
-
-	// Fixup slashes.
-	for( char* Ch = DirNameBuf; *Ch; ++Ch )
-	{
-		if( *Ch == '\\' )
-			*Ch = '/';
-	}
 
 	// Find the directory path by terminating path at the last slash, if any.
 	const char* DirName = NULL;

--- a/Source/Core/Src/UnObj.cpp
+++ b/Source/Core/Src/UnObj.cpp
@@ -2935,7 +2935,7 @@ void CacheDrivers( UBOOL ForceRefresh )
 			if( GSys->Paths[i] )
 			{
 				char Filename[256];
-				appSprintf( Filename, "%s%s", appBaseDir(), GSys->Paths[i] );
+				appSprintf( Filename, "%s%s", appBaseDir(), PATH(GSys->Paths[i]) );
 				char* Tmp = appStrstr( Filename, "*." );
 				if( Tmp )
 				{

--- a/Source/Engine/Src/UnGame.cpp
+++ b/Source/Engine/Src/UnGame.cpp
@@ -376,13 +376,13 @@ UBOOL UGameEngine::Browse( FURL URL, char* Error256 )
 			for( i=0; i<GLevel->GetLevelInfo()->HubStackLevel; i++ )
 			{
 				char Src[256], Dest[256];
-				appSprintf( Src, "%s\\Save%i%i.usa", GSys->SavePath, appAtoi(Option), i );
-				appSprintf( Dest, "%s\\Game%i.usa", GSys->SavePath, i );
+				appSprintf( Src, "%s" PATH_SEPARATOR "Save%i%i.usa", PATH(GSys->SavePath), appAtoi(Option), i );
+				appSprintf( Dest, "%s" PATH_SEPARATOR "Game%i.usa", PATH(GSys->SavePath), i );
 				appCopyFile( Src, Dest );
 			}
 			while( 1 )
 			{
-				appSprintf( Temp, "%s\\Game%i.usa", GSys->SavePath, i++ );
+				appSprintf( Temp, "%s" PATH_SEPARATOR "Game%i.usa", PATH(GSys->SavePath), i++ );
 				if( appFSize(Temp)<=0 )
 					break;
 				appUnlink( Temp );
@@ -485,7 +485,7 @@ ULevel* UGameEngine::LoadMap( const FURL& URL, UPendingLevel* Pending, char* Err
 				Guid = &Connection->Driver->Map(0).Guid;
 			}
 		}
-		LoadObject<ULevel>( MapParent, "MyLevel", *URL.Map, LOAD_Verify | LOAD_Throw | LOAD_KeepImports | LOAD_NoWarn, NULL );
+		LoadObject<ULevel>( MapParent, "MyLevel", PATH(*URL.Map), LOAD_Verify | LOAD_Throw | LOAD_KeepImports | LOAD_NoWarn, NULL );
 	}
 	catch( char* Error )
 	{
@@ -533,7 +533,7 @@ ULevel* UGameEngine::LoadMap( const FURL& URL, UPendingLevel* Pending, char* Err
 			// Save the current level sans players actors.
 			GLevel->CleanupDestroyed( 1 );
 			char Filename[256];
-			appSprintf( Filename, "%s\\Game%i.usa", GSys->SavePath, SavedHubStackLevel );
+			appSprintf( Filename, "%s" PATH_SEPARATOR "Game%i.usa", PATH(GSys->SavePath), SavedHubStackLevel );
 			GObj.SavePackage( GLevel->GetParent(), GLevel, 0, Filename );
 		}
 		GLevel = NULL;
@@ -544,7 +544,7 @@ ULevel* UGameEngine::LoadMap( const FURL& URL, UPendingLevel* Pending, char* Err
 	guard(LoadLevel);
 	if( MapParent && Guid )
 		GObj.GetPackageLinker( MapParent, NULL, LOAD_Verify | LOAD_Throw | LOAD_KeepImports | LOAD_NoWarn, NULL, Guid );
-	GLevel = LoadObject<ULevel>( MapParent, "MyLevel", *URL.Map, LOAD_KeepImports | LOAD_NoFail, NULL );
+	GLevel = LoadObject<ULevel>( MapParent, "MyLevel", PATH(*URL.Map), LOAD_KeepImports | LOAD_NoFail, NULL );
 	check(!GLevel->NetDriver);
 	unguard;
 
@@ -1179,8 +1179,8 @@ void UGameEngine::SaveGame( INT Position )
 {
 	guard(UGameEngine::SaveGame);
 	char Filename[256];
-	appMkdir( GSys->SavePath );
-	appSprintf( Filename, "%s\\Save%i.usa", GSys->SavePath, Position );
+	appMkdir( PATH(GSys->SavePath) );
+	appSprintf( Filename, "%s" PATH_SEPARATOR "Save%i.usa", PATH(GSys->SavePath), Position );
 	GLevel->GetLevelInfo()->LevelAction=LEVACT_Saving;
 	PaintProgress();
 	GSystem->BeginSlowTask( LocalizeProgress("Saving"), 1, 0 );
@@ -1197,13 +1197,13 @@ void UGameEngine::SaveGame( INT Position )
 		for( i=0; i<GLevel->GetLevelInfo()->HubStackLevel; i++ )
 		{
 			char Src[256], Dest[256];
-			appSprintf( Src, "%s\\Game%i.usa", GSys->SavePath, i );
-			appSprintf( Dest, "%s\\Save%i%i.usa", GSys->SavePath, Position, i );
+			appSprintf( Src, "%s" PATH_SEPARATOR "Game%i.usa", PATH(GSys->SavePath), i );
+			appSprintf( Dest, "%s" PATH_SEPARATOR "Save%i%i.usa", PATH(GSys->SavePath), Position, i );
 			appCopyFile( Src, Dest );
 		}
 		while( 1 )
 		{
-			appSprintf( Filename, "%s\\Save%i%i.usa", GSys->SavePath, Position, i++ );
+			appSprintf( Filename, "%s" PATH_SEPARATOR "Save%i%i.usa", PATH(GSys->SavePath), Position, i++ );
 			if( appFSize(Filename)<=0 )
 				break;
 			appUnlink( Filename );

--- a/Source/Engine/Src/UnPawn.cpp
+++ b/Source/Engine/Src/UnPawn.cpp
@@ -220,7 +220,7 @@ void AActor::execGetMapName( FFrame& Stack, BYTE*& Result )
 		if( appStrstr( GSys->Paths[i], Wildcard ) )
 		{
 			char Tmp[256];
-			appStrcpy( Tmp, GSys->Paths[i] );
+			appStrcpy( Tmp, PATH(GSys->Paths[i]) );
 			*appStrstr( Tmp, Wildcard )=0;
 			appStrcat( Tmp, "/" );
 			appStrcat( Tmp, Prefix );


### PR DESCRIPTION
I had some trouble starting a new game on Linux, so I implemented UT-style path normalization. Backslash conversion is now handled in a single place (appUnixPath). I tested save/load, map transitions, new game, but I couldn't try it on Vita, so hopefully I didn't break anything there. Let me know if there's anything to fix.