### PR TITLE
engine: fix level time based lighting effects

### DIFF
--- a/Source/Engine/Src/UnGame.cpp
+++ b/Source/Engine/Src/UnGame.cpp
@@ -707,6 +707,8 @@ ULevel* UGameEngine::LoadMap( const FURL& URL, UPendingLevel* Pending, char* Err
 	{
 		// Lock the level.
 		debugf( NAME_Log, "Bringing %s up for play...", GLevel->GetFullName() );
+		GLevel->TimeSeconds = 0;
+		GLevel->GetLevelInfo()->TimeSeconds = 0;
 
 		// Init touching actors.
 		INT i;


### PR DESCRIPTION
TimeSeconds wasn't initialized after BeginPlay, which caused it to have a large random value. This lead to precision errors and overflows in the light effects that use the level time (e.g. LT_Pulse), essentially rendering them static. This was very apparent in the starting room of Vortex Rikers and the airduct with the green light / fog.