### PR TITLE
OpenAL fixes

### DIFF
--- a/Source/NOpenALDrv/NOpenALDrv.cpp
+++ b/Source/NOpenALDrv/NOpenALDrv.cpp
@@ -569,6 +569,8 @@ void UNOpenALAudioSubsystem::PlayMusic()
 
 	FScopedLock Lock( MusicMutex );
 
+	alSourceStop(MusicSource);
+	ClearMusicBuffers();
 	xmp_set_position( MusicCtx, MusicSection );
 
 	ALint State = 0;

--- a/Source/NOpenALDrv/NOpenALDrv.cpp
+++ b/Source/NOpenALDrv/NOpenALDrv.cpp
@@ -159,6 +159,12 @@ void UNOpenALAudioSubsystem::Destroy()
 		MusicCtx = NULL;
 	}
 
+	if (UseReverb)
+	{
+		alDeleteAuxiliaryEffectSlots(1, &ReverbSlot);
+		alDeleteEffects(1, &ReverbEffect);
+	}
+
 	if( Ctx )
 	{
 		// If we have a context, we probably have everything else. Kill it.
@@ -200,6 +206,11 @@ void UNOpenALAudioSubsystem::ShutdownAfterError()
 		xmp_free_context( MusicCtx );
 		MusicCtx = NULL;
 		Music = NULL;
+	}
+	if (UseReverb)
+	{
+		alDeleteAuxiliaryEffectSlots(1, &ReverbSlot);
+		alDeleteEffects(1, &ReverbEffect);
 	}
 	if( Ctx )
 	{


### PR DESCRIPTION
I noticed that before the subsong changes or a new track starts playing I get a couple seconds of the old music. Clearing the already queued buffers in PlayMusic() solved the problem for the most part. Sometimes I still get a small bit of noise, but it's much less noticeable. 
~I also added a fix for the menu sounds coming from odd directions depending on where you open the menu in the flyby sequence. This is a bit of a hack, but we can assume the game will be paused or player won't be moving when the menu is up in most cases.~