### PR TITLE
Big endian fixes

### DIFF
--- a/Source/Core/Inc/UnFile.h
+++ b/Source/Core/Inc/UnFile.h
@@ -24,6 +24,39 @@ CORE_API extern DWORD GCRCTable[];
 	#define FIRST_BITFIELD   (0x80000000)
 #endif
 
+#if __INTEL__
+	#define INTEL_ORDER16(x)   (x)
+	#define INTEL_ORDER32(x)   (x)
+#else
+	// These macros are not safe to use unless data is UNSIGNED!
+	#define INTEL_ORDER16_unsigned(x)   ((((x)>>8)&0xff)+ (((x)<<8)&0xff00))
+	#define INTEL_ORDER32_unsigned(x)   (((x)>>24) + (((x)>>8)&0xff00) + (((x)<<8)&0xff0000) + ((x)<<24))
+
+	static inline _WORD INTEL_ORDER16(_WORD val)
+	{
+		return(INTEL_ORDER16_unsigned(val));
+	}
+
+	static inline SWORD INTEL_ORDER16(SWORD val)
+	{
+		_WORD uval = *((_WORD *) &val);
+		uval = INTEL_ORDER16(uval);
+		return( *((SWORD *) &uval) );
+	}
+
+	static inline DWORD INTEL_ORDER32(DWORD val)
+	{
+		return(INTEL_ORDER32_unsigned(val));
+	}
+
+	static inline INT INTEL_ORDER32(INT val)
+	{
+		DWORD uval = *((DWORD *) &val);
+		uval = INTEL_ORDER32(uval);
+		return( *((INT *) &uval) );
+	}
+#endif
+
 /*-----------------------------------------------------------------------------
 	Global init and exit.
 -----------------------------------------------------------------------------*/

--- a/Source/Core/Src/UnCorSc.cpp
+++ b/Source/Core/Src/UnCorSc.cpp
@@ -299,10 +299,20 @@ void UObject::execBoolVariable( FFrame& Stack, BYTE*& Result )
 	(this->*GIntrinsics[B])( Stack, *(BYTE**)&GBoolAddr );
 	GProperty = Property;
 
+#if !__INTEL__
+	DWORD OldPropValue = *GBoolAddr;
+	if (*GBoolAddr == 0x00000001 && ((UBoolProperty*)GProperty)->BitMask == FIRST_BITFIELD)
+		*GBoolAddr = FIRST_BITFIELD;
+#endif
+
 	// Note that we're not returning an in-place pointer to to the bool, so EX_Let 
 	// must take special precautions with bools.does
 	if( Result )
 		*(DWORD*)Result = (*GBoolAddr & ((UBoolProperty*)GProperty)->BitMask) ? 1 : 0;
+
+#if !__INTEL__
+	*GBoolAddr = OldPropValue;
+#endif
 
 	unguardexecSlow;
 }

--- a/Source/Core/Src/UnPlat.cpp
+++ b/Source/Core/Src/UnPlat.cpp
@@ -487,6 +487,7 @@ void appInit()
 	GProcessorCount = SDL_GetCPUCount();
 #endif // PLATFORM_
 
+#if __INTEL__
 	// Check processor version with CPUID.
 	DWORD A=0, B=0, C=0, D=0;
 	FGlobalPlatform_CPUID(0,&A,&B,&C,&D);
@@ -544,6 +545,7 @@ void appInit()
 	// Print feature.
 	debugf( NAME_Init, "CPU Detected: %s (%s)", Model, Brand );
 	debugf( NAME_Init, "CPU Features: %s", FeatStr );
+#endif
 
 	// FPU.
 	appEnableFastMath( 0 );

--- a/Source/Engine/Inc/UnTex.h
+++ b/Source/Engine/Inc/UnTex.h
@@ -27,11 +27,11 @@ public:
 	{
 		struct
 		{
-#if __INTEL__
+//#if __INTEL__
 			BYTE R,G,B,A;
-#else
-			BYTE A,B,G,R;
-#endif
+//#else
+//			BYTE A,B,G,R;
+//#endif
 		};
 		struct
 		{

--- a/Source/Engine/Src/UnAudio.cpp
+++ b/Source/Engine/Src/UnAudio.cpp
@@ -119,23 +119,62 @@ UBOOL FWaveModInfo::ReadWaveInfo( TArray<BYTE>& WavData )
 	WaveDataEnd = &WavData(0) + WavData.Num();	
 	
 	// Verify we've got a real 'WAVE' header.
+#if __INTEL__
 	if( RiffHdr->wID != ( mmioFOURCC('W','A','V','E') )  )
 		return 0;
+#else
+	if ( (RiffHdr->wID != (mmioFOURCC('W','A','V','E'))) &&
+		 (RiffHdr->wID != (mmioFOURCC('E','V','A','W'))) )
+	{
+		return 0;
+	}
+
+	bool alreadySwapped = (RiffHdr->wID == (mmioFOURCC('W','A','V','E')));
+	if (!alreadySwapped)
+	{
+		RiffHdr->rID = INTEL_ORDER32(RiffHdr->rID);
+		RiffHdr->ChunkLen = INTEL_ORDER32(RiffHdr->ChunkLen);
+		RiffHdr->wID = INTEL_ORDER32(RiffHdr->wID);
+	}
+#endif
 
 	pMasterSize = &RiffHdr->ChunkLen;
 
 	FRiffChunk* RiffChunk = (FRiffChunk*)&WavData(3*4);
 	// Look for the 'fmt ' chunk.
-	while( ( ((BYTE*)RiffChunk + 8) < WaveDataEnd)  && ( RiffChunk->ChunkID != mmioFOURCC('f','m','t',' ') ) )
+	while( ( ((BYTE*)RiffChunk + 8) < WaveDataEnd)  && ( INTEL_ORDER32(RiffChunk->ChunkID) != mmioFOURCC('f','m','t',' ') ) )
 	{
 		// Go to next chunk.
-		RiffChunk = (FRiffChunk*) ( (BYTE*)RiffChunk + Pad16Bit(RiffChunk->ChunkLen) + 8); 
+		RiffChunk = (FRiffChunk*) ( (BYTE*)RiffChunk + Pad16Bit(INTEL_ORDER32(RiffChunk->ChunkLen)) + 8); 
 	}
 	// Chunk found ?
-	if( RiffChunk->ChunkID != mmioFOURCC('f','m','t',' ') )
+	if( INTEL_ORDER32(RiffChunk->ChunkID) != mmioFOURCC('f','m','t',' ') )
+	{
+#if !__INTEL__  // swap them back just in case.
+		if (!alreadySwapped)
+		{
+			RiffHdr->rID = INTEL_ORDER32(RiffHdr->rID);
+			RiffHdr->ChunkLen = INTEL_ORDER32(RiffHdr->ChunkLen);
+			RiffHdr->wID = INTEL_ORDER32(RiffHdr->wID);
+		}
+#endif
 		return 0;
+	}
 
 	FmtChunk = (FFormatChunk*)((BYTE*)RiffChunk + 8);
+
+#if !__INTEL__
+	if (!alreadySwapped)
+	{
+		FmtChunk->wFormatTag = INTEL_ORDER16(FmtChunk->wFormatTag);
+		FmtChunk->nChannels = INTEL_ORDER16(FmtChunk->nChannels);
+		FmtChunk->nSamplesPerSec = INTEL_ORDER32(FmtChunk->nSamplesPerSec);
+		FmtChunk->nAvgBytesPerSec = INTEL_ORDER32(FmtChunk->nAvgBytesPerSec);
+		FmtChunk->nBlockAlign = INTEL_ORDER16(FmtChunk->nBlockAlign);
+		FmtChunk->wBitsPerSample = INTEL_ORDER16(FmtChunk->wBitsPerSample);
+	}
+#endif
+
 	pBitsPerSample  = &FmtChunk->wBitsPerSample;
 	pSamplesPerSec  = &FmtChunk->nSamplesPerSec;
 	pAvgBytesPerSec = &FmtChunk->nAvgBytesPerSec;
@@ -145,41 +184,111 @@ UBOOL FWaveModInfo::ReadWaveInfo( TArray<BYTE>& WavData )
 	// re-initalize the RiffChunk pointer
 	RiffChunk = (FRiffChunk*)&WavData(3*4);
 	// Look for the 'data' chunk.
-	while( ( ((BYTE*)RiffChunk + 8) < WaveDataEnd) && ( RiffChunk->ChunkID != mmioFOURCC('d','a','t','a') ) )
+	while( ( ((BYTE*)RiffChunk + 8) < WaveDataEnd) && ( INTEL_ORDER32(RiffChunk->ChunkID) != mmioFOURCC('d','a','t','a') ) )
 	{
 		// Go to next chunk.
-		RiffChunk = (FRiffChunk*) ( (BYTE*)RiffChunk + Pad16Bit(RiffChunk->ChunkLen) + 8); 
+		RiffChunk = (FRiffChunk*) ( (BYTE*)RiffChunk + Pad16Bit(INTEL_ORDER32(RiffChunk->ChunkLen)) + 8); 
 	} 
 	// Chunk found ?
-	if( RiffChunk->ChunkID != mmioFOURCC('d','a','t','a') )
+	if( INTEL_ORDER32(RiffChunk->ChunkID) != mmioFOURCC('d','a','t','a') )
+	{
+#if !__INTEL__  // swap them back just in case.
+		if (!alreadySwapped)
+		{
+			RiffHdr->rID = INTEL_ORDER32(RiffHdr->rID);
+			RiffHdr->ChunkLen = INTEL_ORDER32(RiffHdr->ChunkLen);
+			RiffHdr->wID = INTEL_ORDER32(RiffHdr->wID);
+			FmtChunk->wFormatTag = INTEL_ORDER16(FmtChunk->wFormatTag);
+			FmtChunk->nChannels = INTEL_ORDER16(FmtChunk->nChannels);
+			FmtChunk->nSamplesPerSec = INTEL_ORDER32(FmtChunk->nSamplesPerSec);
+			FmtChunk->nAvgBytesPerSec = INTEL_ORDER32(FmtChunk->nAvgBytesPerSec);
+			FmtChunk->nBlockAlign = INTEL_ORDER16(FmtChunk->nBlockAlign);
+			FmtChunk->wBitsPerSample = INTEL_ORDER16(FmtChunk->wBitsPerSample);
+		}
+#endif
 		return 0;
+	}
+
+#if !__INTEL__  // swap them back just in case.
+	if (alreadySwapped) // swap back into Intel order for chunk search...
+		RiffChunk->ChunkLen = INTEL_ORDER32(RiffChunk->ChunkLen);
+#endif
 
 	SampleDataStart = (BYTE*)RiffChunk + 8;
 	pWaveDataSize   = &RiffChunk->ChunkLen;
-	SampleDataSize  =  RiffChunk->ChunkLen;
+	SampleDataSize  =  INTEL_ORDER32(RiffChunk->ChunkLen);
 	OldBitsPerSample = FmtChunk->wBitsPerSample;
 	SampleDataEnd   =  SampleDataStart+SampleDataSize;
 
 	NewDataSize	= SampleDataSize;
 
+#if !__INTEL__
+	if (!alreadySwapped)
+	{
+		if (FmtChunk->wBitsPerSample == 16)
+		{
+			for (_WORD *i = (_WORD *) SampleDataStart; i < (_WORD *) SampleDataEnd; i++)
+			{
+				*i = INTEL_ORDER16(*i);
+			}
+		}
+		else if (FmtChunk->wBitsPerSample == 32)
+		{
+			for (DWORD *i = (DWORD *) SampleDataStart; i < (DWORD *) SampleDataEnd; i++)
+			{
+				*i = INTEL_ORDER32(*i);
+			}
+		}
+	}
+#endif
+
 	// Re-initalize the RiffChunk pointer
 	RiffChunk = (FRiffChunk*)&WavData(3*4);
 	// Look for a 'smpl' chunk.
-	while( ( (((BYTE*)RiffChunk) + 8) < WaveDataEnd) && ( RiffChunk->ChunkID != mmioFOURCC('s','m','p','l') ) )
+	while( ( (((BYTE*)RiffChunk) + 8) < WaveDataEnd) && ( INTEL_ORDER32(RiffChunk->ChunkID) != mmioFOURCC('s','m','p','l') ) )
 	{
 		// Go to next chunk.
-		RiffChunk = (FRiffChunk*) ( (BYTE*)RiffChunk + Pad16Bit(RiffChunk->ChunkLen) + 8); 
+		RiffChunk = (FRiffChunk*) ( (BYTE*)RiffChunk + Pad16Bit(INTEL_ORDER32(RiffChunk->ChunkLen)) + 8); 
 	} 
 
 	// Chunk found ? smpl chunk is optional.
 	// Find the first sample-loop structure, and the total number of them.
-	if( (BYTE*)RiffChunk+4<WaveDataEnd && RiffChunk->ChunkID == mmioFOURCC('s','m','p','l') )
+	if( (BYTE*)RiffChunk+8<WaveDataEnd && INTEL_ORDER32(RiffChunk->ChunkID) == mmioFOURCC('s','m','p','l') )
 	{
 		FSampleChunk* pSampleChunk =  (FSampleChunk*)( (BYTE*)RiffChunk + 8);
+#if !__INTEL__
+		if (!alreadySwapped)
+		{
+			pSampleChunk->dwManufacturer = INTEL_ORDER32(pSampleChunk->dwManufacturer);
+			pSampleChunk->dwProduct = INTEL_ORDER32(pSampleChunk->dwProduct);
+			pSampleChunk->dwSamplePeriod = INTEL_ORDER32(pSampleChunk->dwSamplePeriod);
+			pSampleChunk->dwMIDIUnityNote = INTEL_ORDER32(pSampleChunk->dwMIDIUnityNote);
+			pSampleChunk->dwMIDIPitchFraction = INTEL_ORDER32(pSampleChunk->dwMIDIPitchFraction);
+			pSampleChunk->dwSMPTEFormat = INTEL_ORDER32(pSampleChunk->dwSMPTEFormat);
+			pSampleChunk->dwSMPTEOffset = INTEL_ORDER32(pSampleChunk->dwSMPTEOffset);
+			pSampleChunk->cSampleLoops = INTEL_ORDER32(pSampleChunk->cSampleLoops);
+			pSampleChunk->cbSamplerData = INTEL_ORDER32(pSampleChunk->cbSamplerData);
+		}
+#endif
 		SampleLoopsNum  = pSampleChunk->cSampleLoops; // Number of tSampleLoop structures.
 		// First tSampleLoop structure starts right after the tSampleChunk.
 		pSampleLoop = (FSampleLoop*) ((BYTE*)pSampleChunk + sizeof(FSampleChunk)); 
+#if !__INTEL__
+		if (SampleLoopsNum > 0 && !alreadySwapped)
+		{
+			pSampleLoop->dwIdentifier = INTEL_ORDER32(pSampleLoop->dwIdentifier);
+			pSampleLoop->dwType = INTEL_ORDER32(pSampleLoop->dwType);
+			pSampleLoop->dwStart = INTEL_ORDER32(pSampleLoop->dwStart);
+			pSampleLoop->dwEnd = INTEL_ORDER32(pSampleLoop->dwEnd);
+			pSampleLoop->dwFraction = INTEL_ORDER32(pSampleLoop->dwFraction);
+			pSampleLoop->dwPlayCount = INTEL_ORDER32(pSampleLoop->dwPlayCount);
+		}
+#endif
 	}
+	// Couldn't byte swap this before, since it'd throw off the chunk search.
+#if !__INTEL__
+	*pWaveDataSize = INTEL_ORDER32(*pWaveDataSize);
+#endif
 		
 	return 1;
 	unguard;

--- a/Source/Engine/Src/UnCamera.cpp
+++ b/Source/Engine/Src/UnCamera.cpp
@@ -420,21 +420,21 @@ UBOOL UViewport::Exec( const char* Cmd, FOutputDevice* Out )
 				#pragma pack (pop)
 
 				// File header.
-				FH.bfType		= 'B' + 256*'M';
-				FH.bfSize		= sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + 3 * SizeX * SizeY;
+				FH.bfType		= INTEL_ORDER16((_WORD)('B' + 256*'M'));
+				FH.bfSize		= INTEL_ORDER32((DWORD)(sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + 3 * SizeX * SizeY));
 				FH.bfReserved1	= 0;
 				FH.bfReserved2	= 0;
-				FH.bfOffBits	= sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+				FH.bfOffBits	= INTEL_ORDER32((DWORD)(sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER)));
 				appFwrite( &FH, sizeof(FH), 1, F );
 
 				// Info header.
-				IH.biSize			= sizeof(BITMAPINFOHEADER);
-				IH.biWidth			= SizeX;
-				IH.biHeight			= SizeY;
-				IH.biPlanes			= 1;
-				IH.biBitCount		= 24;
+				IH.biSize			= INTEL_ORDER32((DWORD)sizeof(BITMAPINFOHEADER));
+				IH.biWidth			= INTEL_ORDER32(SizeX);
+				IH.biHeight			= INTEL_ORDER32(SizeY);
+				IH.biPlanes			= INTEL_ORDER16((_WORD)1);
+				IH.biBitCount		= INTEL_ORDER16((_WORD)24);
 				IH.biCompression	= 0; //BI_RGB
-				IH.biSizeImage		= SizeX * SizeY * 3;
+				IH.biSizeImage		= INTEL_ORDER32((DWORD)(SizeX * SizeY * 3));
 				IH.biXPelsPerMeter	= 0;
 				IH.biYPelsPerMeter	= 0;
 				IH.biClrUsed		= 0;

--- a/Source/Engine/Src/UnTex.cpp
+++ b/Source/Engine/Src/UnTex.cpp
@@ -297,6 +297,21 @@ void UTexture::Serialize( FArchive& Ar )
 		UBits = FLogTwo(USize);
 		VBits = FLogTwo(VSize);
 	}
+
+#if !__INTEL__
+	// PolyFlags isn't a proper bitfield, so the bits have to be reversed
+	if ( /*Ar.IsSaving() ||*/ Ar.IsLoading())
+	{
+		DWORD OldPolyFlags = PolyFlags;
+		PolyFlags = 0;
+		for (INT i = 0; i < 32; i++)
+		{
+			PolyFlags <<= 1;
+			PolyFlags |= (OldPolyFlags & 1);
+			OldPolyFlags >>= 1;
+		}
+	}
+#endif
 	unguard;
 }
 void UTexture::Export( FOutputDevice& Out, const char* FileType, int Indent )

--- a/Source/NOpenGLDrv/NOpenGLDrv.cpp
+++ b/Source/NOpenGLDrv/NOpenGLDrv.cpp
@@ -846,14 +846,32 @@ void UNOpenGLRenderDevice::ConvertTextureMipI8( const FMipmap* Mip, const FColor
 		if( Masked )
 		{
 			// index 0 is transparent
+#if __INTEL__
 			for( i = 0; i < Count; ++i, ++Src )
 				*Dst++ = *Src ? ( Pal[*Src] | ALPHA_MASK ) : 0;
+#else
+			for( i = 0; i < Count; ++i, ++Src )
+			{
+				FColor Color = Palette[*Src];
+				Color.A = *Src ? 255 : 0;
+				*Dst++ = (Color.R << 24) | (Color.G << 16) | (Color.B << 8) | Color.A;
+			}
+#endif
 		}
 		else
 		{
 			// index 0 is whatever
+#if __INTEL__
 			for( i = 0; i < Count; ++i )
 				*Dst++ = ( Pal[*Src++] | ALPHA_MASK );
+#else
+			for( i = 0; i < Count; ++i, ++Src )
+			{
+				FColor Color = Palette[*Src];
+				Color.A = 255;
+				*Dst++ = (Color.R << 24) | (Color.G << 16) | (Color.B << 8) | Color.A;
+			}
+#endif
 		}
 	}
 }

--- a/Source/NOpenGLESDrv/NOpenGLESDrv.cpp
+++ b/Source/NOpenGLESDrv/NOpenGLESDrv.cpp
@@ -958,14 +958,32 @@ void UNOpenGLESRenderDevice::UploadTexture( FTextureInfo& Info, UBOOL Masked, UB
 			if( Masked )
 			{
 				// index 0 is transparent
+#if __INTEL__
 				for( DWORD i = 0; i < Count; ++i, ++Src )
 					*Dst++ = *Src ? ( Pal[*Src] | ALPHA_MASK ) : 0;
+#else
+				for( i = 0; i < Count; ++i, ++Src )
+				{
+					FColor Color = Palette[*Src];
+					Color.A = *Src ? 255 : 0;
+					*Dst++ = (Color.R << 24) | (Color.G << 16) | (Color.B << 8) | Color.A;
+				}
+#endif
 			}
 			else
 			{
 				// index 0 is whatever
+#if __INTEL__
 				for( DWORD i = 0; i < Count; ++i )
 					*Dst++ = ( Pal[*Src++] | ALPHA_MASK );
+#else
+				for( DWORD i = 0; i < Count; ++i, ++Src )
+				{
+					FColor Color = Palette[*Src];
+					Color.A = 255;
+					*Dst++ = (Color.R << 24) | (Color.G << 16) | (Color.B << 8) | Color.A;
+				}
+#endif
 			}
 		}
 		else if( UseBGRA )

--- a/Source/Render/Src/UnLight.cpp
+++ b/Source/Render/Src/UnLight.cpp
@@ -507,6 +507,14 @@ void FLightManager::ShadowMapGen( FTextureInfo& Tex, BYTE* SrcBits, BYTE* Dest1 
 		if( V == 0            ) Dests[0] -= Size4;
 		if( V == Tex.VClamp-2 ) Dests[2] -= Size4;
 	}
+#if !__INTEL__
+	Size4 = (ShadowMaskSpace*8)/4;
+	DWORD* DestDW = (DWORD*)Dest1;
+	for( INT i=0; i<Size4; i++ )
+	{
+		DestDW[i] = INTEL_ORDER32(DestDW[i]);
+	}
+#endif
 	unguardSlow;
 }
 


### PR DESCRIPTION
This fixes all the problems I could find running on big endian systems. FColor had an unnecessary fix that only made things worse, since all of the game expects the bytes to be in R,G,B,A order. The only place where this isn't true is the palleted texture conversion functions for OpenGL.