### PR TITLE
GLES Texture conversion refactor

### DIFF
--- a/Source/NOpenGLDrv/NOpenGLDrv.cpp
+++ b/Source/NOpenGLDrv/NOpenGLDrv.cpp
@@ -106,8 +106,7 @@ UBOOL UNOpenGLRenderDevice::Init( UViewport* InViewport )
 
 	debugf( NAME_Log, "Got OpenGL %d.%d", GLVersion.major, GLVersion.minor );
 
-	ComposeSize = 256 * 256 * 4;
-	Compose = (BYTE*)appMalloc( ComposeSize, "GLComposeBuf" );
+	EnsureComposeSize( 256 * 256 * 4 );
 	verify( Compose );
 
 	// Set modelview matrix to flip stuff into our coordinate system.
@@ -801,6 +800,7 @@ void UNOpenGLRenderDevice::EnsureComposeSize( const DWORD NewSize )
 {
 	if( NewSize > ComposeSize )
 	{
+		ComposeSize = NewSize;
 		Compose = (BYTE*)appRealloc( Compose, NewSize, "GLComposeBuf" );
 	}
 	verify( Compose );

--- a/Source/NOpenGLESDrv/NOpenGLESDrv.cpp
+++ b/Source/NOpenGLESDrv/NOpenGLESDrv.cpp
@@ -1008,9 +1008,6 @@ void UNOpenGLESRenderDevice::UploadTexture( FTextureInfo& Info, UBOOL Masked, UB
 		return;
 	}
 
-	// We're gonna be using the compose buffer, so expand it to fit.
-	EnsureComposeSize(Info.Mips[0]->USize * Info.Mips[0]->VSize * 4);
-
 	// Upload all mips.
 	for( INT MipIndex = 0; MipIndex < Info.NumMips; ++MipIndex )
 	{

--- a/Source/NOpenGLESDrv/NOpenGLESDrvPrivate.h
+++ b/Source/NOpenGLESDrv/NOpenGLESDrvPrivate.h
@@ -177,6 +177,9 @@ class DLL_EXPORT UNOpenGLESRenderDevice : public URenderDevice
 	void SetTexture( INT TMU, FTextureInfo& Info, DWORD PolyFlags, FLOAT PanBias );
 	void ResetTexture( INT TMU );
 	void UploadTexture( FTextureInfo& Info, UBOOL Masked, UBOOL NewTexture );
+	void EnsureComposeSize( const DWORD NewSize );
+	void ConvertTextureMipI8( const FMipmap* Mip, const FColor* Palette, const UBOOL Masked, BYTE*& UploadBuf, GLenum& UploadFormat );
+	void ConvertTextureMipBGRA7777( const FMipmap* Mip, BYTE*& UploadBuf, GLenum& UploadFormat );
 	void UpdateTextureFilter( const FTextureInfo& Info, DWORD PolyFlags );
 	void UpdateSwapInterval();
 


### PR DESCRIPTION
In the GLES renderer I extracted the EnsureComposeSize, ConvertTextureMipI8, ConvertTextureMipBGRA7777 functions, so it's closer to the regular GL renderer. The latter had a small oversight, ComposeSize wasn't updated by EnsureComposeSize, so the buffer was always reallocated for textures larger than the default 256x256.