### PR TITLE
Increase the far clipping plane

### DIFF
--- a/Source/NOpenGLDrv/NOpenGLDrv.cpp
+++ b/Source/NOpenGLDrv/NOpenGLDrv.cpp
@@ -653,7 +653,7 @@ void UNOpenGLRenderDevice::SetSceneNode( FSceneNode* Frame )
 		RFY2 = 2.0f * RProjZ * Aspect / Frame->FY;
 		glMatrixMode( GL_PROJECTION );
 		glLoadIdentity();
-		glFrustum( -RProjZ, +RProjZ, -Aspect * RProjZ, +Aspect * RProjZ, 1.0, 32768.0 );
+		glFrustum( -RProjZ, +RProjZ, -Aspect * RProjZ, +Aspect * RProjZ, 1.0, 65336.0 );
 		CurrentSceneNode.FX = Frame->FX;
 		CurrentSceneNode.FY = Frame->FY;
 		CurrentSceneNode.FovAngle = Viewport->Actor->FovAngle;

--- a/Source/NOpenGLESDrv/NOpenGLESDrv.cpp
+++ b/Source/NOpenGLESDrv/NOpenGLESDrv.cpp
@@ -757,7 +757,7 @@ void UNOpenGLESRenderDevice::SetSceneNode( FSceneNode* Frame )
 		Aspect = Frame->FY / Frame->FX;
 		RFX2 = 2.0f * RProjZ / Frame->FX;
 		RFY2 = 2.0f * RProjZ * Aspect / Frame->FY;
-		MtxProj = glm::frustum( -RProjZ, +RProjZ, -Aspect * RProjZ, +Aspect * RProjZ, 1.f, 32768.f );
+		MtxProj = glm::frustum( -RProjZ, +RProjZ, -Aspect * RProjZ, +Aspect * RProjZ, 1.f, 65336.f );
 		MtxMVP = MtxProj * MtxModelView;
 		CurrentSceneNode.FX = Frame->FX;
 		CurrentSceneNode.FY = Frame->FY;


### PR DESCRIPTION
On Spire Village and The Sunspire the distant mountains kept clipping away, so I doubled the far plane to 65336. This is the same value used by XOpenGLDrv, so there's probably no harm in doing this. 